### PR TITLE
feat(accuracy): add `NO_POWER` priority to `LocationAccuracy`

### DIFF
--- a/openlocate/src/main/java/com/openlocate/android/core/LocationAccuracy.java
+++ b/openlocate/src/main/java/com/openlocate/android/core/LocationAccuracy.java
@@ -26,7 +26,8 @@ import com.google.android.gms.location.LocationRequest;
 public enum LocationAccuracy {
     LOW(LocationRequest.PRIORITY_LOW_POWER),
     MEDIUM(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY),
-    HIGH(LocationRequest.PRIORITY_HIGH_ACCURACY);
+    HIGH(LocationRequest.PRIORITY_HIGH_ACCURACY),
+    NO_POWER(LocationRequest.PRIORITY_NO_POWER);
 
     private final int locationRequestAccuracy;
     LocationAccuracy(int locationRequestAccuracy) {

--- a/openlocate/src/test/java/com/openlocate/android/core/LocationAccuracyTests.java
+++ b/openlocate/src/test/java/com/openlocate/android/core/LocationAccuracyTests.java
@@ -33,6 +33,7 @@ public class LocationAccuracyTests {
         Assert.assertEquals(LocationAccuracy.HIGH.toString(), "high");
         Assert.assertEquals(LocationAccuracy.LOW.toString(), "low");
         Assert.assertEquals(LocationAccuracy.MEDIUM.toString(), "medium");
+        Assert.assertEquals(LocationAccuracy.NO_POWER.toString(), "no_power");
     }
 
     @Test
@@ -40,6 +41,7 @@ public class LocationAccuracyTests {
         Assert.assertEquals(LocationAccuracy.HIGH.getLocationRequestAccuracy(), LocationRequest.PRIORITY_HIGH_ACCURACY);
         Assert.assertEquals(LocationAccuracy.MEDIUM.getLocationRequestAccuracy(), LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
         Assert.assertEquals(LocationAccuracy.LOW.getLocationRequestAccuracy(), LocationRequest.PRIORITY_LOW_POWER);
+        Assert.assertEquals(LocationAccuracy.NO_POWER.getLocationRequestAccuracy(), LocationRequest.PRIORITY_NO_POWER);
     }
 
     @Test
@@ -47,6 +49,7 @@ public class LocationAccuracyTests {
         Assert.assertEquals(LocationAccuracy.valueOf("HIGH"), LocationAccuracy.HIGH);
         Assert.assertEquals(LocationAccuracy.valueOf("LOW"), LocationAccuracy.LOW);
         Assert.assertEquals(LocationAccuracy.valueOf("MEDIUM"), LocationAccuracy.MEDIUM);
+        Assert.assertEquals(LocationAccuracy.valueOf("NO_POWER"), LocationAccuracy.NO_POWER);
     }
 
     @Test


### PR DESCRIPTION
Is there are reason not to allow SDK users to use the `PRIORITY_NO_POWER` priority for location updates?

see https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest#PRIORITY_NO_POWER