### PR TITLE
Fix crash caused by Not allowed to start service

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The following fields are collected by the SDK to be sent to a private or public 
 12. `device_manufacturer` - Manufacturer of device
 13. `device_model` - Model of devise
 14. `os` - Operating system installed on Device.
-15. `location_method` - Method of location collected i.e "wifi", "cellular", "fused", "gps"
+15. `location_method` - Method of location collected i.e "gps", "network", "passive"
 16. `location_context` -  Indicates whether the location was collected when the application was foregrounded or backgrounded on the device.
 17. `carrier_name` - Name of the mobile network carrier
 18. `connection_type` - Collects devices's network connection type

--- a/openlocate/src/main/java/com/openlocate/android/core/OpenLocate.java
+++ b/openlocate/src/main/java/com/openlocate/android/core/OpenLocate.java
@@ -616,6 +616,8 @@ public class OpenLocate implements OpenLocateLocationTracker {
             setStartedPreferences();
         } catch (SecurityException e) {
             Log.e(TAG, "Could not start location service");
+        } catch (IllegalStateException e1){
+            Log.e(TAG, "Not allowed to start location service");
         }
     }
 


### PR DESCRIPTION
# This PR contains the tow following changes:

## 1. Fix crash caused by java.lang.IllegalStateException: Not allowed to start service Intent.
This crash is easily to recreate in users's Android O devices and mine. It happens after installation. Here is the log:

Fatal Exception: java.lang.IllegalStateException: Not allowed to start service Intent { cmp=com.quoord.tapatalkpro.activity/com.openlocate.android.core.LocationService (has extras) }: app is in background uid UidRecord{b90c40 u0a710 CEM  idle procs:2 seq(0,0,0)}
&nbsp;&nbsp;&nbsp;&nbsp;at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1538)
&nbsp;&nbsp;&nbsp;&nbsp;at android.app.ContextImpl.startService(ContextImpl.java:1484)
&nbsp;&nbsp;&nbsp;&nbsp;at android.content.ContextWrapper.startService(ContextWrapper.java:663)
&nbsp;&nbsp;&nbsp;&nbsp;at com.openlocate.android.core.OpenLocate.initialize(Unknown Source:66)
&nbsp;&nbsp;&nbsp;&nbsp;at com.openlocate.android.core.OpenLocate$2.onAdvertisingInfoTaskExecute(Unknown Source:2)
&nbsp;&nbsp;&nbsp;&nbsp;at com.openlocate.android.core.FetchAdvertisingInfoTask.onPostExecute(Unknown Source:13)
&nbsp;&nbsp;&nbsp;&nbsp;at android.os.AsyncTask.finish(AsyncTask.java:695)
&nbsp;&nbsp;&nbsp;&nbsp;at android.os.AsyncTask.-wrap1(Unknown Source)
&nbsp;&nbsp;&nbsp;&nbsp;at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:712)
&nbsp;&nbsp;&nbsp;&nbsp;at android.os.Handler.dispatchMessage(Handler.java:105)

## 2. Update README.md
According to the [LocationProvider](https://github.com/OpenLocate/openlocate-android/blob/06e1987355962e29835897004bc8c2e7071c8a83/openlocate/src/main/java/com/openlocate/android/core/LocationProvider.java#L30-L33), the value of location_method will only be among gps, network, passive.

@kurabi Please review.